### PR TITLE
Update Tooltip.lua - Fix learnability of recipes with double colon

### DIFF
--- a/Altoholic/Services/Tooltip.lua
+++ b/Altoholic/Services/Tooltip.lua
@@ -45,12 +45,16 @@ local function GetCraftNameFromRecipeLink(link)
 	local craftName
 
 	-- try to determine if it's a transmute (has 2 colons in the string --> Alchemy: Transmute: blablabla)
+	--[[
 	local pos = string.find(recipeName, L["Transmute"])
 	if pos then	-- it's a transmute
 		return string.sub(recipeName, pos, -2)
 	else
 		craftName = select(2, strsplit(":", recipeName))
 	end
+	]]--
+        -- there's more than just transmutes now, so rejoin anything with extra colons
+	craftName = strjoin(":", select(2, strsplit(":", recipeName)))
 	
 	if craftName == nil then		-- will be nil for enchants
 		return string.sub(recipeName, 3, -2)		-- ex: "Enchant Weapon - Striking"

--- a/Altoholic/Services/Tooltip.lua
+++ b/Altoholic/Services/Tooltip.lua
@@ -45,14 +45,6 @@ local function GetCraftNameFromRecipeLink(link)
 	local craftName
 
 	-- try to determine if it's a transmute (has 2 colons in the string --> Alchemy: Transmute: blablabla)
-	--[[
-	local pos = string.find(recipeName, L["Transmute"])
-	if pos then	-- it's a transmute
-		return string.sub(recipeName, pos, -2)
-	else
-		craftName = select(2, strsplit(":", recipeName))
-	end
-	]]--
         -- there's more than just transmutes now, so rejoin anything with extra colons
 	craftName = strjoin(":", select(2, strsplit(":", recipeName)))
 	

--- a/Altoholic/Services/Tooltip.lua
+++ b/Altoholic/Services/Tooltip.lua
@@ -44,7 +44,7 @@ local function GetCraftNameFromRecipeLink(link)
 	local recipeName = select(4, strsplit("|", link))
 	local craftName
 
-        -- Some recipes (transmutes, drake techniques, etc) have multiple colons in the name. rejoin everything after the first
+	-- Some recipes (transmutes, drake techniques, etc) have multiple colons in the name. rejoin everything after the first
 	craftName = strjoin(":", select(2, strsplit(":", recipeName)))
 	
 	if craftName == nil then		-- will be nil for enchants
@@ -279,7 +279,7 @@ function addon:GetRecipeOwners(professionName, link, recipeLevel)
 			craftName = strtrim(craftName)
 		end
 	end
-	
+
 	local know = {}				-- list of alts who know this recipe
 	local couldLearn = {}		-- list of alts who could learn it
 	local willLearn = {}			-- list of alts who will be able to learn it later
@@ -306,13 +306,13 @@ function addon:GetRecipeOwners(professionName, link, recipeLevel)
 
 					if string.lower(skillName) == string.lower(craftName) and isLearned then
 					        if isEnchant then		-- matched "Strength" for instance, now check that it's the right category (eg. "Bracer" not "Chest")
-							local skillCategoryID = C_TradeSkillUI.GetRecipeInfo(recipeID).categoryID
-							local skillCategory = C_TradeSkillUI.GetCategoryInfo(skillCategoryID).name
+							local skillCategoryID = C_TradeSkillUI.GetRecipeInfo(recipeID, 1).categoryID
+							local skillCategory = (skillCategoryID and C_TradeSkillUI.GetCategoryInfo(skillCategoryID).name) or ""
 							skillCategory = string.gsub(skillCategory, " Enchantments", "")
 
 							if skillCategory == categoryName then
 								isKnownByChar = true
-								return true
+								return true	-- stop iteration
 							end
 
 						else

--- a/Altoholic/Services/Tooltip.lua
+++ b/Altoholic/Services/Tooltip.lua
@@ -307,7 +307,7 @@ function addon:GetRecipeOwners(professionName, link, recipeLevel)
 					if string.lower(skillName) == string.lower(craftName) and isLearned then
 					        if isEnchant then		-- matched "Strength" for instance, now check that it's the right category (eg. "Bracer" not "Chest")
 							local skillCategoryID = C_TradeSkillUI.GetRecipeInfo(recipeID, 1).categoryID
-							local skillCategory = (skillCategoryID and C_TradeSkillUI.GetCategoryInfo(skillCategoryID).name) or ""
+							local skillCategory = (skillCategoryID and C_TradeSkillUI.GetCategoryInfo(skillCategoryID) and C_TradeSkillUI.GetCategoryInfo(skillCategoryID).name) or ""
 							skillCategory = string.gsub(skillCategory, " Enchantments", "")
 
 							if skillCategory == categoryName then

--- a/Altoholic/Services/Tooltip.lua
+++ b/Altoholic/Services/Tooltip.lua
@@ -44,19 +44,7 @@ local function GetCraftNameFromRecipeLink(link)
 	local recipeName = select(4, strsplit("|", link))
 	local craftName
 
-	-- try to determine if it's a transmute (has 2 colons in the string --> Alchemy: Transmute: blablabla)
-<<<<<<< Updated upstream
-        -- there's more than just transmutes now, so rejoin anything with extra colons
-=======
-	--[[
-	local pos = string.find(recipeName, L["Transmute"])
-	if pos then	-- it's a transmute
-		return string.sub(recipeName, pos, -2)
-	else
-		craftName = select(2, strsplit(":", recipeName))
-	end
-	]]--
->>>>>>> Stashed changes
+        -- Some recipes (transmutes, drake techniques, etc) have multiple colons in the name. rejoin everything after the first
 	craftName = strjoin(":", select(2, strsplit(":", recipeName)))
 	
 	if craftName == nil then		-- will be nil for enchants

--- a/Altoholic/Services/Tooltip.lua
+++ b/Altoholic/Services/Tooltip.lua
@@ -45,13 +45,24 @@ local function GetCraftNameFromRecipeLink(link)
 	local craftName
 
 	-- try to determine if it's a transmute (has 2 colons in the string --> Alchemy: Transmute: blablabla)
+<<<<<<< Updated upstream
         -- there's more than just transmutes now, so rejoin anything with extra colons
+=======
+	--[[
+	local pos = string.find(recipeName, L["Transmute"])
+	if pos then	-- it's a transmute
+		return string.sub(recipeName, pos, -2)
+	else
+		craftName = select(2, strsplit(":", recipeName))
+	end
+	]]--
+>>>>>>> Stashed changes
 	craftName = strjoin(":", select(2, strsplit(":", recipeName)))
 	
 	if craftName == nil then		-- will be nil for enchants
 		return string.sub(recipeName, 3, -2)		-- ex: "Enchant Weapon - Striking"
 	end
-	
+
 	return string.sub(craftName, 2, -2)	-- at this point, get rid of the leading space and trailing square bracket
 end
 
@@ -187,7 +198,7 @@ local function IsItemAccountBound(itemLink)
 	for i = 1, numLines do		-- parse the first 5 lines maximum
 		local tooltipText = _G[format("%sTextLeft%d", tooltipName, i)]:GetText()
 		
-		if tooltipText == ITEM_BIND_TO_BNETACCOUNT or tooltipText == ITEM_BNETACCOUNTBOUND then
+		if tooltipText == ITEM_BIND_TO_BNETACCOUNT or tooltipText == ITEM_BNETACCOUNTBOUND or tooltipText == ITEM_BIND_TO_ACCOUNT or tooltipText == ITEM_ACCOUNTBOUND then
 			return true
 		end
 	end
@@ -292,6 +303,8 @@ function addon:GetRecipeOwners(professionName, link, recipeLevel)
 				DataStore:IterateRecipes(profession, 0, 0, function(recipeData)
 					local _, recipeID, isLearned = DataStore:GetRecipeInfo(recipeData)
 					local skillName = GetSpellInfo(recipeID) or ""
+
+					skillName = string.gsub(skillName, "Proto Drake", "Proto-Drake") -- this is silly. There's a typo in the Blizz spell list
 
 					if string.lower(skillName) == string.lower(craftName) and isLearned then
 						isKnownByChar = true


### PR DESCRIPTION
Recipes with two colons in the recipe name are showing as "Learnable by:" characters who already know them. Changed handling to be more generic, rather than only looking for "Transmute".