### PR TITLE
Added more slots to RecipeRow xml and lua

### DIFF
--- a/Altoholic_Characters/Templates/RecipeRow.lua
+++ b/Altoholic_Characters/Templates/RecipeRow.lua
@@ -96,7 +96,7 @@ addon:Controller("AltoholicUI.TabCharacters.RecipeRow", {
 		end
 		
 		-- hide unused reagent icons
-		while index <= 8 do
+		while index <= 11 do
 			frame[format("Reagent%d", index)]:Hide()
 			index = index + 1
 		end

--- a/Altoholic_Characters/Templates/RecipeRow.xml
+++ b/Altoholic_Characters/Templates/RecipeRow.xml
@@ -127,6 +127,21 @@
 					<Anchor point="TOPLEFT" relativeKey="$parent.Reagent7" relativePoint="TOPRIGHT" x="5" y="0" />
 				</Anchors>
 			</Button>
+			<Button parentKey="Reagent9" inherits="AltoItemIconTemplate">
+				<Anchors>
+					<Anchor point="TOPLEFT" relativeKey="$parent.Reagent8" relativePoint="TOPRIGHT" x="5" y="0" />
+				</Anchors>
+			</Button>
+			<Button parentKey="Reagent10" inherits="AltoItemIconTemplate">
+				<Anchors>
+					<Anchor point="TOPLEFT" relativeKey="$parent.Reagent9" relativePoint="TOPRIGHT" x="5" y="0" />
+				</Anchors>
+			</Button>
+			<Button parentKey="Reagent11" inherits="AltoItemIconTemplate">
+				<Anchors>
+					<Anchor point="TOPLEFT" relativeKey="$parent.Reagent10" relativePoint="TOPRIGHT" x="5" y="0" />
+				</Anchors>
+			</Button>
 		</Frames>
 		<Scripts>
 			<OnLoad>


### PR DESCRIPTION
RecipeRow only has slots for 8 reagents, but some recipes take up to 11 (Crackling Codex of the Isles). Added more button slots to RecipeRow.xml, and increased corresponding counter in RecipeRow.lua.
- This isn't perfect - when Altoholic is at minimum size, the buttons overflow the pane.
![WoWScrnShot_020124-Altoholic](https://github.com/Thaoky/Altoholic_Retail/assets/12279608/ad5b6032-0e1e-40e3-8123-6338bc70df1a)
