### PR TITLE
Allow hiding equipped item counts in tooltips.

### DIFF
--- a/Altoholic/Core.lua
+++ b/Altoholic/Core.lua
@@ -197,7 +197,8 @@ AddonFactory:OnAddonLoaded(addonName, function()
 		ShowGuildBankCountPerTab = false,	-- guild count = guild:count or guild (tab 1: x, tab2: y ..)
 		ShowCouldBeStoredOn = false,			-- display "could be stored on" information
 		ShowAccountBankCount = true,			-- display account bank counters
-		
+		ShowInventoryItemCount = true,		-- display equipped item counters
+
 		HiddenGuilds = {}						-- Guilds that should not be shown in the tooltip
 	})	
 	

--- a/Altoholic/Services/Tooltip.lua
+++ b/Altoholic/Services/Tooltip.lua
@@ -114,7 +114,11 @@ local function GetCharacterItemCount(character, searchedID)
 	itemCounts[3] = DataStore:GetVoidStorageItemCount(character, searchedID)
 	itemCounts[4] = DataStore:GetReagentBankItemCount(character, searchedID)
 	itemCounts[5] = DataStore:GetAuctionHouseItemCount(character, searchedID)
-	itemCounts[6] = DataStore:GetInventoryItemCount(character, searchedID)
+	if options["ShowInventoryItemCount"] then
+		itemCounts[6] = DataStore:GetInventoryItemCount(character, searchedID)
+	else
+		itemCounts[6] = 0
+	end
 	itemCounts[7] = DataStore:GetMailItemCount(character, searchedID)
 	
 	local charCount = 0

--- a/Altoholic_Options/Frames/Settings_Altoholic_Tooltip.lua
+++ b/Altoholic_Options/Frames/Settings_Altoholic_Tooltip.lua
@@ -34,6 +34,7 @@ addon:Controller("AltoholicUI.TabOptions.SettingsAltoholicTooltip", function()
 			frame.ShowMergedRealmsCount:SetChecked(options.ShowMergedRealmsCount)
 			frame.ShowAllRealmsCount:SetChecked(options.ShowAllRealmsCount)
 			frame.ShowAllAccountsCount:SetChecked(options.ShowAllAccountsCount)
+			frame.ShowInventoryItemCount:SetChecked(options.ShowInventoryItemCount)
 			
 			frame.ShowAccountBankCount:SetChecked(options.ShowAccountBankCount)
 			frame.ShowGuildBankCount:SetChecked(options.ShowGuildBankCount)

--- a/Altoholic_Options/Frames/Settings_Altoholic_Tooltip.xml
+++ b/Altoholic_Options/Frames/Settings_Altoholic_Tooltip.xml
@@ -260,6 +260,18 @@
 					<KeyValue key="locDisabled" value="TT_SHOW_HEARTHSTONE_DISABLED" />
 				</KeyValues>
 			</CheckButton>
+			<CheckButton parentKey="ShowInventoryItemCount" inherits="AltoTooltipOptionTemplate">
+				<Anchors> 
+					<Anchor point="TOPLEFT" relativeKey="$parent.ShowHearthstoneCount" relativePoint="BOTTOMLEFT" x="0" y="-10" />
+				</Anchors>
+				<KeyValues>
+					<KeyValue key="option" value="ShowInventoryItemCount" />
+					<KeyValue key="locLabel" value="TT_SHOW_INVENTORYITEM_TEXT" />
+					<KeyValue key="locTitle" value="TT_SHOW_INVENTORYITEM_TITLE" />
+					<KeyValue key="locEnabled" value="TT_SHOW_INVENTORYITEM_ENABLED" />
+					<KeyValue key="locDisabled" value="TT_SHOW_INVENTORYITEM_DISABLED" />
+				</KeyValues>
+			</CheckButton>
 		</Frames>
 		<Scripts>
 			<OnLoad>

--- a/Altoholic_Options/Locales/enUS.lua
+++ b/Altoholic_Options/Locales/enUS.lua
@@ -241,6 +241,11 @@ L["TT_SHOW_HEARTHSTONE_TITLE"] = "Show counters for hearthstones"
 L["TT_SHOW_HEARTHSTONE_ENABLED"] = "Display counters when mousing over a hearthstone, the Admiral's Compass, or the Flight Master's Whistle."
 L["TT_SHOW_HEARTHSTONE_DISABLED"] = "Hide the counters when mousing over one of these items."
 
+L["TT_SHOW_INVENTORYITEM_TEXT"] = "Show counters for equipped items"
+L["TT_SHOW_INVENTORYITEM_TITLE"] = "Show counters for equipped items"
+L["TT_SHOW_INVENTORYITEM_ENABLED"] = "Display counters when mousing over an equipped item."
+L["TT_SHOW_INVENTORYITEM_DISABLED"] = "Hide the counters when mousing over one of these items."
+
 
 -- ** Settings / Altoholic / Calendar **
 L["Calendar Options"] = true


### PR DESCRIPTION
All my alts have common profession items like the Wildercloth Chef's Hat. This uses up the available tooltip lines when looking for those in containers to use for weekly profession quests. This option omits equipped items from the tooltip.