### PR TITLE
Guard nil item counts in tooltip aggregation

### DIFF
--- a/Altoholic/Services/Tooltip.lua
+++ b/Altoholic/Services/Tooltip.lua
@@ -128,12 +128,14 @@ end
 
 local function GetCharacterItemCount(character, searchedID)
 	itemCounts[1], itemCounts[2], itemCounts[9] = DataStore:GetContainerItemCount(character, searchedID)
-	itemCounts[2] = itemCounts[2] + (DataStore:GetPlayerBankItemCount(character, searchedID) or 0)
-	itemCounts[3] = DataStore:GetVoidStorageItemCount(character, searchedID)
-	itemCounts[4] = DataStore:GetReagentBankItemCount(character, searchedID)
-	itemCounts[5] = DataStore:GetAuctionHouseItemCount(character, searchedID)
-	itemCounts[6] = DataStore:GetInventoryItemCount(character, searchedID)
-	itemCounts[7] = DataStore:GetMailItemCount(character, searchedID)
+	itemCounts[1] = itemCounts[1] or 0
+	itemCounts[2] = (itemCounts[2] or 0) + (DataStore:GetPlayerBankItemCount(character, searchedID) or 0)
+	itemCounts[9] = itemCounts[9] or 0
+	itemCounts[3] = DataStore:GetVoidStorageItemCount(character, searchedID) or 0
+	itemCounts[4] = DataStore:GetReagentBankItemCount(character, searchedID) or 0
+	itemCounts[5] = DataStore:GetAuctionHouseItemCount(character, searchedID) or 0
+	itemCounts[6] = DataStore:GetInventoryItemCount(character, searchedID) or 0
+	itemCounts[7] = DataStore:GetMailItemCount(character, searchedID) or 0
 	
 	local charCount = 0
 	for _, v in pairs(itemCounts) do


### PR DESCRIPTION
`DataStore:GetContainerItemCount` can return fewer than three values when a character's containers have not been scanned, leaving `itemCounts[2]` nil. The next line `itemCounts[2] + (...)` then crashes with `attempt to perform arithmetic on field '?' (a nil value)`. The same risk exists for any other `DataStore:Get*ItemCount` call used a few lines below.

This patch defaults each `itemCounts` entry to 0 so the `pairs()` sum loop and the per-entry `if v > 0` checks stay safe.

Fixes #98.