### PR TITLE
Hide equipped item counts in tooltips (rebased from #84)

### DIFF
--- a/Altoholic/Core.lua
+++ b/Altoholic/Core.lua
@@ -198,7 +198,7 @@ AddonFactory:OnAddonLoaded(addonName, function()
 		ShowCouldBeStoredOn = false,			-- display "could be stored on" information
 		ShowAccountBankCount = true,			-- display account bank counters
 		ShowCurrenciesCount = true,			-- display currency counters
-		
+		ShowInventoryItemCount = true,		-- display equipped item counters
 		HiddenGuilds = {}						-- Guilds that should not be shown in the tooltip
 	})	
 	

--- a/Altoholic/Services/Tooltip.lua
+++ b/Altoholic/Services/Tooltip.lua
@@ -132,7 +132,11 @@ local function GetCharacterItemCount(character, searchedID)
 	itemCounts[3] = DataStore:GetVoidStorageItemCount(character, searchedID)
 	itemCounts[4] = DataStore:GetReagentBankItemCount(character, searchedID)
 	itemCounts[5] = DataStore:GetAuctionHouseItemCount(character, searchedID)
-	itemCounts[6] = DataStore:GetInventoryItemCount(character, searchedID)
+	if options["ShowInventoryItemCount"] then
+		itemCounts[6] = DataStore:GetInventoryItemCount(character, searchedID)
+	else
+		itemCounts[6] = 0
+	end
 	itemCounts[7] = DataStore:GetMailItemCount(character, searchedID)
 	
 	local charCount = 0

--- a/Altoholic_Options/Frames/Settings_Altoholic_Tooltip.lua
+++ b/Altoholic_Options/Frames/Settings_Altoholic_Tooltip.lua
@@ -34,6 +34,7 @@ addon:Controller("AltoholicUI.TabOptions.SettingsAltoholicTooltip", function()
 			frame.ShowMergedRealmsCount:SetChecked(options.ShowMergedRealmsCount)
 			frame.ShowAllRealmsCount:SetChecked(options.ShowAllRealmsCount)
 			frame.ShowAllAccountsCount:SetChecked(options.ShowAllAccountsCount)
+			frame.ShowInventoryItemCount:SetChecked(options.ShowInventoryItemCount)
 			
 			frame.ShowAccountBankCount:SetChecked(options.ShowAccountBankCount)
 			frame.ShowGuildBankCount:SetChecked(options.ShowGuildBankCount)

--- a/Altoholic_Options/Frames/Settings_Altoholic_Tooltip.xml
+++ b/Altoholic_Options/Frames/Settings_Altoholic_Tooltip.xml
@@ -261,7 +261,7 @@
 				</KeyValues>
 			</CheckButton>
 			<CheckButton parentKey="ShowCurrenciesCount" inherits="AltoTooltipOptionTemplate">
-				<Anchors> 
+				<Anchors>
 					<Anchor point="TOPLEFT" relativeKey="$parent.ShowHearthstoneCount" relativePoint="BOTTOMLEFT" x="0" y="-10" />
 				</Anchors>
 				<KeyValues>
@@ -270,6 +270,18 @@
 					<KeyValue key="locTitle" value="TT_SHOW_CURRENCIES_TITLE" />
 					<KeyValue key="locEnabled" value="TT_SHOW_CURRENCIES_ENABLED" />
 					<KeyValue key="locDisabled" value="TT_SHOW_CURRENCIES_DISABLED" />
+				</KeyValues>
+			</CheckButton>
+			<CheckButton parentKey="ShowInventoryItemCount" inherits="AltoTooltipOptionTemplate">
+				<Anchors>
+					<Anchor point="TOPLEFT" relativeKey="$parent.ShowCurrenciesCount" relativePoint="BOTTOMLEFT" x="0" y="-10" />
+				</Anchors>
+				<KeyValues>
+					<KeyValue key="option" value="ShowInventoryItemCount" />
+					<KeyValue key="locLabel" value="TT_SHOW_INVENTORYITEM_TEXT" />
+					<KeyValue key="locTitle" value="TT_SHOW_INVENTORYITEM_TITLE" />
+					<KeyValue key="locEnabled" value="TT_SHOW_INVENTORYITEM_ENABLED" />
+					<KeyValue key="locDisabled" value="TT_SHOW_INVENTORYITEM_DISABLED" />
 				</KeyValues>
 			</CheckButton>
 		</Frames>

--- a/Altoholic_Options/Locales/enUS.lua
+++ b/Altoholic_Options/Locales/enUS.lua
@@ -246,6 +246,11 @@ L["TT_SHOW_CURRENCIES_TITLE"] = "Show counters for currencies"
 L["TT_SHOW_CURRENCIES_ENABLED"] = "Display counters when mousing over a currency."
 L["TT_SHOW_CURRENCIES_DISABLED"] = "Hide the counters when mousing over a currency."
 
+L["TT_SHOW_INVENTORYITEM_TEXT"] = "Show counters for equipped items"
+L["TT_SHOW_INVENTORYITEM_TITLE"] = "Show counters for equipped items"
+L["TT_SHOW_INVENTORYITEM_ENABLED"] = "Display counters when mousing over an equipped item."
+L["TT_SHOW_INVENTORYITEM_DISABLED"] = "Hide the counters when mousing over one of these items."
+
 
 -- ** Settings / Altoholic / Calendar **
 L["Calendar Options"] = true


### PR DESCRIPTION
Rebase of @SpareSimian's #84 onto current `development`. The original PR has been open since 2025-09-02; this resolves the conflicts that emerged after development moved forward, so it can be reviewed without churn.

Three conflicts (`Core.lua`, `Settings_Altoholic_Tooltip.xml`, `enUS.lua`) were all from independent additions in the same vicinity as `ShowCurrenciesCount` and `TT_SHOW_CURRENCIES_*` that landed on development separately. Both sides were kept — no semantic overlap.

Authorship is preserved on the original commit. Closes #72, supersedes #84.