### PR TITLE
Bump Interface to 120005 (WoW 12.0.5)

### DIFF
--- a/Altoholic/Altoholic.toc
+++ b/Altoholic/Altoholic.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 120000
+﻿## Interface: 120005
 ## Title: Altoholic by |cFF69CCF0Thaoky|r
 ## IconTexture: Interface\Icons\inv_drink_13
 

--- a/Altoholic_Achievements/Altoholic_Achievements.toc
+++ b/Altoholic_Achievements/Altoholic_Achievements.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 120000
+﻿## Interface: 120005
 ## Title: Altoholic_Achievements
 ## IconTexture: Interface\Icons\inv_drink_13
 

--- a/Altoholic_Agenda/Altoholic_Agenda.toc
+++ b/Altoholic_Agenda/Altoholic_Agenda.toc
@@ -1,4 +1,4 @@
-## Interface: 120000
+## Interface: 120005
 ## Title: Altoholic_Agenda
 ## IconTexture: Interface\Icons\inv_drink_13
 

--- a/Altoholic_Characters/Altoholic_Characters.toc
+++ b/Altoholic_Characters/Altoholic_Characters.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 120000
+﻿## Interface: 120005
 ## Title: Altoholic_Characters
 ## IconTexture: Interface\Icons\inv_drink_13
 

--- a/Altoholic_Grids/Altoholic_Grids.toc
+++ b/Altoholic_Grids/Altoholic_Grids.toc
@@ -1,4 +1,4 @@
-## Interface: 120000
+## Interface: 120005
 ## Title: Altoholic_Grids
 ## IconTexture: Interface\Icons\inv_drink_13
 

--- a/Altoholic_Guild/Altoholic_Guild.toc
+++ b/Altoholic_Guild/Altoholic_Guild.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 120000
+﻿## Interface: 120005
 ## Title: Altoholic_Guild
 ## IconTexture: Interface\Icons\inv_drink_13
 

--- a/Altoholic_Options/Altoholic_Options.toc
+++ b/Altoholic_Options/Altoholic_Options.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 120000
+﻿## Interface: 120005
 ## Title: Altoholic_Options
 ## IconTexture: Interface\Icons\inv_drink_13
 

--- a/Altoholic_Search/Altoholic_Search.toc
+++ b/Altoholic_Search/Altoholic_Search.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 120000
+﻿## Interface: 120005
 ## Title: Altoholic_Search
 ## IconTexture: Interface\Icons\inv_drink_13
 

--- a/Altoholic_Summary/Altoholic_Summary.toc
+++ b/Altoholic_Summary/Altoholic_Summary.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 120000
+﻿## Interface: 120005
 ## Title: Altoholic_Summary
 ## IconTexture: Interface\Icons\inv_drink_13
 


### PR DESCRIPTION
The Retail client is on 12.0.5 (build 67602, released 2026-05-15) but the nine `Altoholic_*` .toc files still declare `## Interface: 120000`, so the addon list shows them as "Out of Date" until users enable "Load out of date AddOns".

Bumps all nine to `120005`. No code changes; nothing else in the .toc files touched (BOMs and CRLF line endings preserved).