### PR TITLE
Use dynamic MAX_PLAYER_LEVEL in summary filters

### DIFF
--- a/Altoholic_Summary/Services/Characters.lua
+++ b/Altoholic_Summary/Services/Characters.lua
@@ -8,7 +8,7 @@ local oop = MVC:GetService("AddonFactory.Classes")
 local Formatter = MVC:GetService("AltoholicUI.Formatter")
 local AccountSharing = MVC:GetService("AltoholicUI.AccountSharing")
 
-local MAX_PLAYER_LEVEL = 80
+local MAX_PLAYER_LEVEL = GetMaxLevelForPlayerExpansion()
 
 local INFO_REALM_LINE = 0
 local INFO_CHARACTER_LINE = 1


### PR DESCRIPTION
Follow-up to c5b797e ("Make MAX_PLAYER_LEVEL more dynamic") on the same branch.

`Altoholic_Summary/Columns_CharacterInformation.lua` was updated to read `GetMaxLevelForPlayerExpansion()`, but the twin constant at `Altoholic_Summary/Services/Characters.lua:11` was missed and is still hardcoded to `80`. It feeds the "fully rested" character filter:

```lua
elseif misc == 4 then        -- fully rested ?
    local level = DataStore:GetCharacterLevel(character)
    if level == MAX_PLAYER_LEVEL then
        return false
    end
    ...
```

So a fully rested level-90 character is incorrectly considered rest-eligible — the filter doesn't recognise it as max-level.

Mirrors the upstream pattern by reading `GetMaxLevelForPlayerExpansion()` once at load.